### PR TITLE
Standardize batch format. Introduce batch postprocessing.

### DIFF
--- a/projects/cifar10/experiments/monai_bundle_prototype.yaml
+++ b/projects/cifar10/experiments/monai_bundle_prototype.yaml
@@ -104,4 +104,11 @@ system:
           target_transform: null
 
         predict: "%#test"
-        
+    
+    postprocessing:
+        # Format the batch as required by Lighter
+        batch:
+            train: '$lambda x: {"input": x[0], "target": x[1]}'
+            val: "%#train"
+            test: "%#train"
+            predict: "%#train"

--- a/tests/integration/test_cifar.py
+++ b/tests/integration/test_cifar.py
@@ -1,4 +1,5 @@
 """Tests for running CIFAR training to verify integrity of the pipeline"""
+
 import pytest
 
 from lighter.utils.cli import run_trainer_method

--- a/tests/unit/test_dummy.py
+++ b/tests/unit/test_dummy.py
@@ -1,4 +1,5 @@
 """Tests for hello function."""
+
 import pytest
 
 from lighter.utils.misc import ensure_list


### PR DESCRIPTION
## Description

Defined a clear batch format requirement. A batch must be a `Dict` containing `"input"` (required), `"target"` (optional), and/or `"id"` (optional).

Simplified the criterion calculation - `"target"` will be passed to the criterion if it's in the batch instead of checking if criterion has a `target` argument.

`LighterSystem`'s `postprocessing` now includes `batch` in addition to the existing `criterion`, `metrics`, and `logging`. This allows easy manipulation of the batch data primarily to get it in the correct format where that is not possible/convenient with Transforms - for example [torchvision's CIFAR10 dataset](https://github.com/pytorch/vision/blob/9cb639a1f41abf20b8f7bc82bcfee0ccf3e7ccb4/torchvision/datasets/cifar.py#L124).

## Related Issue
None

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/lighter/lighter/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/lighter/lighter/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
