### PR TITLE
Make checkpoint loading more informative. Remove incorrect Metric type check. Make TableWriter expect a path instead of dir.

### DIFF
--- a/lighter/callbacks/writer/table.py
+++ b/lighter/callbacks/writer/table.py
@@ -16,14 +16,14 @@ class LighterTableWriter(LighterBaseWriter):
     Writer for saving predictions in a table format.
 
     Args:
-        directory (Path): Directory where the CSV will be saved.
+        path (Path): CSV filepath.
         writer (Union[str, Callable]): Name of the writer function registered in `self.writers` or a custom writer function.
             Available writers: "tensor". A custom writer function must take a single argument: `tensor`, and return the record
             to be saved in the CSV file. The tensor will be a single tensor without the batch dimension.
     """
 
-    def __init__(self, directory: Union[str, Path], writer: Union[str, Callable]) -> None:
-        super().__init__(directory, writer)
+    def __init__(self, path: Union[str, Path], writer: Union[str, Callable]) -> None:
+        super().__init__(path, writer)
         self.csv_records = {}
 
     @property
@@ -52,8 +52,6 @@ class LighterTableWriter(LighterBaseWriter):
         If training was done in a distributed setting, it gathers predictions from all processes
         and then saves them from the rank 0 process.
         """
-        csv_path = self.directory / "predictions.csv"
-
         # Sort the records by ID and convert the dictionary to a list
         self.csv_records = [self.csv_records[id] for id in sorted(self.csv_records)]
 
@@ -69,4 +67,4 @@ class LighterTableWriter(LighterBaseWriter):
 
         # Save the records to a CSV file
         if trainer.is_global_zero:
-            pd.DataFrame(self.csv_records).to_csv(csv_path)
+            pd.DataFrame(self.csv_records).to_csv(self.path)

--- a/lighter/system.py
+++ b/lighter/system.py
@@ -254,8 +254,6 @@ class LighterSystem(pl.LightningModule):
         # Metrics
         if metrics is not None:
             for name, metric in metrics.items():
-                if not isinstance(metric, Metric):
-                    raise TypeError(f"Expected type for metric is 'Metric', got '{type(metric).__name__}' instead.")
                 on_step_log(f"{mode}/metrics/{name}/step", metric)
                 on_epoch_log(f"{mode}/metrics/{name}/epoch", metric)
         # Optimizer's lr, momentum, beta. Logged in train mode and once per epoch.

--- a/lighter/utils/model.py
+++ b/lighter/utils/model.py
@@ -98,11 +98,14 @@ def adjust_prefix_and_load_state_dict(
                 # Add the model_prefix before the current key name if there's no specific ckpt_prefix
                 ckpt = {f"{model_prefix}{key}": value for key, value in ckpt.items() if ckpt_prefix in key}
 
-    # Check if there is no overlap between the checkpoint's and model's state_dict.
-    if not set(ckpt.keys()) & set(model.state_dict().keys()):
+    # Check if the checkpoint's and model's state_dicts have no overlap.
+    model_keys = list(model.state_dict().keys())
+    ckpt_keys = list(ckpt.keys())
+    if not set(ckpt_keys) & set(model_keys):
         raise ValueError(
-            "There is no overlap between checkpoint's and model's state_dict. Check their "
-            "`state_dict` keys and adjust accordingly using `ckpt_prefix` and `model_prefix`."
+            "There is no overlap between checkpoint's and model's state_dict."
+            f"\nModel keys: '{model_keys[0]}', ..., '{model_keys[-1]}', "
+            f"\nCheckpoint keys: '{ckpt_keys[0]}', ..., '{ckpt_keys[-1]}'"
         )
 
     # Remove the layers that are not to be loaded.


### PR DESCRIPTION
## Description

Time for v0.0.3 https://github.com/project-lighter/lighter/issues/118

## Related Issue

https://github.com/project-lighter/lighter/issues/125
https://github.com/project-lighter/lighter/issues/121
https://github.com/project-lighter/lighter/issues/90

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/lighter/lighter/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/lighter/lighter/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced flexibility in specifying save paths, which can now be directories or files, for data logging and saving.
  
- **Bug Fixes**
  - Improved consistency in path handling across distributed environments to prevent potential errors during training and prediction phases.
  
- **Refactor**
  - Updated internal logic for setting and validating paths, ensuring smoother and more reliable operation.
  
- **Improvements**
  - Enhanced error messages for better troubleshooting during model state dictionary loading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->