### PR TITLE
Default dataloaders to Iterable

### DIFF
--- a/lighter/system.py
+++ b/lighter/system.py
@@ -109,7 +109,7 @@ class LighterSystem(pl.LightningModule):
         self.inferer = inferer
 
         # Bypasses LightningModule's check for dataloader and step methods. We define them dynamically in self.setup().
-        self.train_dataloader = self.val_dataloader = self.test_dataloader = self.predict_dataloader = lambda: None
+        self.train_dataloader = self.val_dataloader = self.test_dataloader = self.predict_dataloader = lambda: []
         self.training_step = self.validation_step = self.test_step = self.predict_step = lambda: None
 
     def forward(self, input: Union[Tensor, List[Tensor], Tuple[Tensor], Dict[str, Tensor]]) -> Any:


### PR DESCRIPTION
```TypeError: An invalid dataloader was returned from `LighterSystem.val_dataloader()`. Found None.```

is thrown when running a SSL pre-training example without the validation dataset. 

Converting this to an empty list seems to fix the issue. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated data loader methods to return an empty list instead of `None`, ensuring proper functionality.
	- Corrected indentation for the assignment of `self.inferer` within the initialization method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->