### PR TITLE
Fix metrics device

### DIFF
--- a/lighter/system.py
+++ b/lighter/system.py
@@ -3,10 +3,10 @@ This module defines the System class, which encapsulates the components of a dee
 including the model, optimizer, datasets, and more. It extends PyTorch Lightning's LightningModule.
 """
 
-from typing import Any
-
+import contextlib
 from collections.abc import Callable
 from dataclasses import asdict
+from typing import Any
 
 import pytorch_lightning as pl
 from torch import Tensor
@@ -175,10 +175,10 @@ class System(pl.LightningModule):
             metrics = getattr(self.metrics, self.mode)
             if metrics is not None:
                 adapters = getattr(self.adapters, self.mode)
-                try:
+                # Move metrics to the same device as input if they have the 'to' method,
+                # which probably means they are an instance of torchmetrics.MetricCollection
+                with contextlib.suppress(AttributeError):
                     metrics = metrics.to(input.device)
-                except AttributeError:
-                    pass
                 metrics = adapters.metrics(metrics, input, target, pred)
         return metrics
 

--- a/lighter/system.py
+++ b/lighter/system.py
@@ -174,6 +174,10 @@ class System(pl.LightningModule):
             metrics = getattr(self.metrics, self.mode)
             if metrics is not None:
                 adapters = getattr(self.adapters, self.mode)
+                try:
+                    metrics = metrics.to(input.device)
+                except AttributeError:
+                    pass
                 metrics = adapters.metrics(metrics, input, target, pred)
         return metrics
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

I was getting the following error:

```python-traceback
RuntimeError: Encountered different devices in metric calculation (see stacktrace for details). This could be due to the metric class not being on the same device as input. Instead of
`metric=MulticlassAccuracy(...)` try to do `metric=MulticlassAccuracy(...).to(device)` where device corresponds to the device of the input.
```

The change is in this PR fixed the error, but I'm not 100% sure this is desired in the context of the rest of the codebase.



<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/lighter/lighter/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/lighter/lighter/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device compatibility for metrics calculation, ensuring metrics are moved to the correct device when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->